### PR TITLE
GraphDriverData.Data might be null

### DIFF
--- a/api-model-v1-41/docker-engine-api-v1.41.yaml
+++ b/api-model-v1-41/docker-engine-api-v1.41.yaml
@@ -1499,7 +1499,7 @@ definitions:
         x-nullable: false
       Data:
         type: "object"
-        x-nullable: false
+        x-nullable: true
         additionalProperties:
           type: "string"
 

--- a/api-model-v1-41/src/main/kotlin/de/gesellix/docker/remote/api/GraphDriverData.kt
+++ b/api-model-v1-41/src/main/kotlin/de/gesellix/docker/remote/api/GraphDriverData.kt
@@ -24,5 +24,5 @@ data class GraphDriverData(
   @Json(name = "Name")
   val name: kotlin.String,
   @Json(name = "Data")
-  val data: kotlin.collections.Map<kotlin.String, kotlin.String>
+  val data: kotlin.collections.Map<kotlin.String, kotlin.String>?
 )


### PR DESCRIPTION
Seen on Ubuntu Linux/amd64 with Docker 20.10.11, api v1.41, containerd 1.4.12, runc 1.0.2