### PR TITLE
Make the api backwards compatible with Docker 18.06.1-ce, API version 1.38

### DIFF
--- a/api-model-v1-41/docker-engine-api-v1.41.yaml
+++ b/api-model-v1-41/docker-engine-api-v1.41.yaml
@@ -5733,7 +5733,7 @@ paths:
               Warnings:
                 description: "Warnings encountered when creating the container"
                 type: "array"
-                x-nullable: false
+                x-nullable: true
                 items:
                   type: "string"
           examples:

--- a/api-model-v1-41/src/main/kotlin/de/gesellix/docker/remote/api/ContainerCreateResponse.kt
+++ b/api-model-v1-41/src/main/kotlin/de/gesellix/docker/remote/api/ContainerCreateResponse.kt
@@ -26,5 +26,5 @@ data class ContainerCreateResponse(
   var id: kotlin.String,
   /* Warnings encountered when creating the container */
   @Json(name = "Warnings")
-  var warnings: kotlin.collections.List<kotlin.String>
+  var warnings: kotlin.collections.List<kotlin.String>?
 )


### PR DESCRIPTION
Works around:

```
Caused by: com.squareup.moshi.JsonDataException: Non-null value 'warnings' (JSON name 'Warnings') was null at $.Warnings
 	at com.squareup.moshi.internal.Util.unexpectedNull(Util.java:663)
 	at de.gesellix.docker.remote.api.ContainerCreateResponseJsonAdapter.fromJson(ContainerCreateResponseJsonAdapter.kt:45)
 	at de.gesellix.docker.remote.api.ContainerCreateResponseJsonAdapter.fromJson(ContainerCreateResponseJsonAdapter.kt:22)
 	at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
 	at com.squareup.moshi.JsonAdapter.fromJson(JsonAdapter.java:70)
 	at de.gesellix.docker.remote.api.client.ContainerApi.containerCreate(ContainerApi.kt:2093)
```
