### PR TITLE
Migrate from org.jetbrains.kotlin.kapt to com.google.devtools.ksp

### DIFF
--- a/api-model-v1-41/build.gradle.kts
+++ b/api-model-v1-41/build.gradle.kts
@@ -4,7 +4,7 @@ import java.util.*
 plugins {
   id("java")
   id("org.jetbrains.kotlin.jvm")
-  id("org.jetbrains.kotlin.kapt")
+  id("com.google.devtools.ksp")
   id("maven-publish")
   id("signing")
   id("com.github.ben-manes.versions")
@@ -70,7 +70,7 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31")
 
   implementation("com.squareup.moshi:moshi:1.12.0")
-  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
+  ksp("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   id("io.freefair.maven-central.validate-poms") version "6.4.0"
   id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
   id("org.jetbrains.kotlin.jvm") version "1.5.31" apply false
-  id("org.jetbrains.kotlin.kapt") version "1.5.31" apply false
+  id("com.google.devtools.ksp") version("1.6.0-1.0.1") apply false
   id("org.openapi.generator") version "5.2.0" apply false
   id("org.jlleitschuh.gradle.ktlint") version "10.2.1" apply false
 }


### PR DESCRIPTION
See https://github.com/square/moshi#codegen for the Moshi codegen docs.
Let's see how far we can go without upgrading to Kotlin 1.6 (and thus increasing the risk of forcing downstream users to upgrade to Kotlin 1.6, too).

Kapt is in maintenance mode since late 2021, see the docs at https://kotlinlang.org/docs/kapt.html and the issue at https://youtrack.jetbrains.com/issue/KT-48661.

Relates to https://youtrack.jetbrains.com/issue/KT-45545
