### PR TITLE
Require okio >= 3.x

### DIFF
--- a/api-model-v1-41/build.gradle.kts
+++ b/api-model-v1-41/build.gradle.kts
@@ -68,10 +68,15 @@ repositories {
 
 dependencies {
   constraints {
-    implementation("com.squareup.okio:okio") {
-      version {
-        strictly("[2.5,4)")
-        prefer("3.1.0")
+    listOf(
+      "com.squareup.okio:okio",
+      "com.squareup.okio:okio-jvm"
+    ).forEach {
+      implementation(it) {
+        version {
+          strictly("[3,4)")
+          prefer("3.1.0")
+        }
       }
     }
   }


### PR DESCRIPTION
Explicitly using okio-jvm makes the artifacts Maven-compatible.

Relates to https://github.com/gesellix/docker-client/issues/245