### PR TITLE
Add format "int64" to HealthConfig

### DIFF
--- a/api-model-v1-41/docker-engine-api-v1.41.yaml
+++ b/api-model-v1-41/docker-engine-api-v1.41.yaml
@@ -725,11 +725,13 @@ definitions:
           The time to wait between checks in nanoseconds. It should be 0 or at
           least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Timeout:
         description: |
           The time to wait before considering the check to have hung. It should
           be 0 or at least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Retries:
         description: |
           The number of consecutive failures needed to consider a container as
@@ -741,6 +743,7 @@ definitions:
           health-retries countdown in nanoseconds. It should be 0 or at least
           1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
 
   Health:
     description: |

--- a/api-model-v1-41/docs/HealthConfig.md
+++ b/api-model-v1-41/docs/HealthConfig.md
@@ -5,10 +5,10 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **test** | **kotlin.collections.MutableList&lt;kotlin.String&gt;** | The test to perform. Possible values are:  - &#x60;[]&#x60; inherit healthcheck from image or parent image - &#x60;[\&quot;NONE\&quot;]&#x60; disable healthcheck - &#x60;[\&quot;CMD\&quot;, args...]&#x60; exec arguments directly - &#x60;[\&quot;CMD-SHELL\&quot;, command]&#x60; run command with system&#39;s default shell  |  [optional]
-**interval** | **kotlin.Int** | The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  |  [optional]
-**timeout** | **kotlin.Int** | The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  |  [optional]
+**interval** | **kotlin.Long** | The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  |  [optional]
+**timeout** | **kotlin.Long** | The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  |  [optional]
 **retries** | **kotlin.Int** | The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit.  |  [optional]
-**startPeriod** | **kotlin.Int** | Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  |  [optional]
+**startPeriod** | **kotlin.Long** | Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  |  [optional]
 
 
 

--- a/api-model-v1-41/src/main/kotlin/de/gesellix/docker/remote/api/HealthConfig.kt
+++ b/api-model-v1-41/src/main/kotlin/de/gesellix/docker/remote/api/HealthConfig.kt
@@ -41,11 +41,11 @@ data class HealthConfig(
 
   /* The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  */
   @Json(name = "Interval")
-  var interval: kotlin.Int? = null,
+  var interval: kotlin.Long? = null,
 
   /* The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  */
   @Json(name = "Timeout")
-  var timeout: kotlin.Int? = null,
+  var timeout: kotlin.Long? = null,
 
   /* The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit.  */
   @Json(name = "Retries")
@@ -53,6 +53,6 @@ data class HealthConfig(
 
   /* Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.  */
   @Json(name = "StartPeriod")
-  var startPeriod: kotlin.Int? = null
+  var startPeriod: kotlin.Long? = null
 
 )


### PR DESCRIPTION
Since the Docker API Specification defines the fields "interval", "timeout" and "start_period" for health checks as "nanoseconds" the correct data type should be Long.